### PR TITLE
Fix mess-up with FFMPEG-docker sub-module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Docker_ffmpeg/ffmpeg"]
+	path = Docker_ffmpeg/ffmpeg
+	url = https://github.com/jrottenberg/ffmpeg.git

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 1. Docker__ffmpeg\ffmpeg:
-    A folder for the docker
+    FFMPEG Docker Submodule (from https://github.com/jrottenberg/ffmpeg)
     
 2. PSNR_calculate.py:
     1. A script that runs on the folder of all the videos which contains the videos


### PR DESCRIPTION
Three steps:
   1) Remove mistakenly pushed sub-repo
   2) Add the jrottenberg/ffmpeg ffmpeg-docker project as a submodule
   3) Update Readme with sub-module description 